### PR TITLE
Remove private_key field

### DIFF
--- a/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/v0x18/Transformer.kt
+++ b/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/v0x18/Transformer.kt
@@ -1508,7 +1508,6 @@ internal class Transformer(var auth: String) : DatatypesMapper {
             actor_id = d.actor_id,
             last_refreshed_at = addTimezoneOffset(d.last_refreshed_at),
             inbox_url = d.inbox_url,
-            private_key = d.private_key,
             instance_id = d.instance_id,
         )
 

--- a/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/v0x18/datatypes/Site.kt
+++ b/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/v0x18/datatypes/Site.kt
@@ -14,7 +14,6 @@ internal data class Site(
     val description: String? = null,
     val actor_id: String,
     val last_refreshed_at: String,
-    val private_key: String? = null,
     val inbox_url: String,
     val instance_id: InstanceId,
 )

--- a/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/v0x19/datatypes/Site.kt
+++ b/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/v0x19/datatypes/Site.kt
@@ -15,6 +15,5 @@ data class Site(
     val actor_id: String,
     val last_refreshed_at: String,
     val inbox_url: String,
-    val private_key: String? = null,
     val instance_id: InstanceId,
 )


### PR DESCRIPTION
This field is removed from the API in Lemmy 1.9.4