### PR TITLE
Make Protocol field nullable in NodeInfo field

### DIFF
--- a/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/LemmyApi.kt
+++ b/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/LemmyApi.kt
@@ -80,7 +80,7 @@ object LemmyApi {
      * Returns if it is a fediverse instance, meaning it supports ActivityPub protocol
      */
     fun isFediverse(nodeInfo: NodeInfo): Boolean {
-        return nodeInfo.protocols.contains("activitypub")
+        return nodeInfo.protocols?.contains("activitypub") ?: false
     }
 
     /**

--- a/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/dto/NodeInfo.kt
+++ b/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/dto/NodeInfo.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 data class NodeInfo(
     val version: String,
     val software: NodeInfoSoftware,
-    val protocols: List<String>,
+    val protocols: List<String>?,
     val openRegistrations: Boolean,
     val usage: NodeInfoUsage,
 )

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ POM_DEVELOPER_URL=https://github.com/MV-GH
 
 POM_ARTIFACT_ID=lemmy-api
 GROUP=it.vercruysse.lemmyapi
-VERSION_NAME=0.2.14-SNAPSHOT
+VERSION_NAME=0.2.15-SNAPSHOT


### PR DESCRIPTION
For private instances, Lemmy sets this as null. This might be against the spec but I will have to support this anyway.

http://nodeinfo.diaspora.software/docson/index.html#/ns/schema/2.0

see https://github.com/LemmyNet/jerboa/issues/1487