### PR TITLE
Fixing default_comment_sort_type

### DIFF
--- a/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/datatypes/CreateSite.kt
+++ b/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/datatypes/CreateSite.kt
@@ -8,6 +8,7 @@ import it.vercruysse.lemmyapi.enums.ListingType
 import it.vercruysse.lemmyapi.enums.PostListingMode
 import it.vercruysse.lemmyapi.enums.RegistrationMode
 import it.vercruysse.lemmyapi.enums.SortType
+import it.vercruysse.lemmyapi.enums.CommentSortType
 import kotlinx.serialization.Serializable
 
 @CommonParcelize
@@ -27,7 +28,7 @@ data class CreateSite(
     val default_post_time_range_seconds: Long? = null,
     /** Added in 1.0.0 */
     val default_items_per_page: Long? = null,
-    val default_comment_sort_type: SortType? /* "Hot" | "Top" | "New" | "Old" | "Controversial" */ = null,
+    val default_comment_sort_type: CommentSortType? = null,
     val legal_information: String? = null,
     val application_email_admins: Boolean? = null,
     /** Added in 1.0.0 */

--- a/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/datatypes/EditSite.kt
+++ b/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/datatypes/EditSite.kt
@@ -8,6 +8,7 @@ import it.vercruysse.lemmyapi.enums.ListingType
 import it.vercruysse.lemmyapi.enums.PostListingMode
 import it.vercruysse.lemmyapi.enums.RegistrationMode
 import it.vercruysse.lemmyapi.enums.SortType
+import it.vercruysse.lemmyapi.enums.CommentSortType
 import kotlinx.serialization.Serializable
 
 @CommonParcelize
@@ -28,7 +29,7 @@ data class EditSite(
     val default_post_sort_type: SortType? /* "Active" | "Hot" | "New" | "Old" | "TopDay" | "TopWeek" | "TopMonth" | "TopYear" | "TopAll" | "MostComments" | "NewComments" | "TopHour" | "TopSixHour" | "TopTwelveHour" | "TopThreeMonths" | "TopSixMonths" | "TopNineMonths" | "Controversial" | "Scaled" */ = null,
     val default_post_time_range_seconds: Long? = null,
     val default_items_per_page: Long? = null,
-    val default_comment_sort_type: SortType? /* "hot" | "top" | "new" | "old" | "controversial" */ = null,
+    val default_comment_sort_type: CommentSortType? = null,
     val legal_information: String? = null,
     val application_email_admins: Boolean? = null,
     /** Added in 1.0.0 */

--- a/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/datatypes/LocalSite.kt
+++ b/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/datatypes/LocalSite.kt
@@ -34,7 +34,7 @@ data class LocalSite(
     val federation_signed_fetch: Boolean,
     val default_post_listing_mode: PostListingMode /* "List" | "Card" | "SmallCard" */,
     val default_post_sort_type: SortType /* "Active" | "Hot" | "New" | "Old" | "TopDay" | "TopWeek" | "TopMonth" | "TopYear" | "TopAll" | "MostComments" | "NewComments" | "TopHour" | "TopSixHour" | "TopTwelveHour" | "TopThreeMonths" | "TopSixMonths" | "TopNineMonths" | "Controversial" | "Scaled" */,
-    val default_comment_sort_type: SortType /* "Hot" | "Top" | "New" | "Old" | "Controversial" */,
+    val default_comment_sort_type: CommentSortType? = null,
     val oauth_registration: Boolean,
     val post_upvotes: FederationMode /* "All" | "Local" | "Disable" */,
     val post_downvotes: FederationMode /* "All" | "Local" | "Disable" */,

--- a/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/datatypes/LocalUser.kt
+++ b/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/datatypes/LocalUser.kt
@@ -6,6 +6,7 @@ import it.vercruysse.lemmyapi.Identity
 import it.vercruysse.lemmyapi.enums.ListingType
 import it.vercruysse.lemmyapi.enums.PostListingMode
 import it.vercruysse.lemmyapi.enums.SortType
+import it.vercruysse.lemmyapi.enums.CommentSortType
 import it.vercruysse.lemmyapi.enums.VoteShow
 import kotlinx.serialization.Serializable
 
@@ -37,7 +38,7 @@ data class LocalUser(
     val private_messages_enabled: Boolean,
     val collapse_bot_comments: Boolean,
     /** Added in 1.0.0 */
-    val default_comment_sort_type: SortType,
+    val default_comment_sort_type: CommentSortType,
     /** Added in 1.0.0 */
     val auto_mark_fetched_posts_as_read: Boolean,
     /** Added in 0.19.11 */

--- a/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/v1/x0/x0/datatypes/CreateSite.kt
+++ b/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/v1/x0/x0/datatypes/CreateSite.kt
@@ -23,7 +23,7 @@ internal data class CreateSite(
     val default_post_sort_type: SortType? /* "active" | "hot" | "new" | "old" | "top" | "most_comments" | "new_comments" | "controversial" | "scaled" */ = null,
     val default_post_time_range_seconds: Long? = null,
     val default_items_per_page: Long? = null,
-    val default_comment_sort_type: SortType? /* "hot" | "top" | "new" | "old" | "controversial" */ = null,
+    val default_comment_sort_type: CommentSortType? = null,
     val legal_information: String? = null,
     val application_email_admins: Boolean? = null,
     val discussion_languages: List<LanguageId>? = null,

--- a/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/v1/x0/x0/datatypes/LocalSite.kt
+++ b/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/v1/x0/x0/datatypes/LocalSite.kt
@@ -30,7 +30,7 @@ internal data class LocalSite(
     val federation_signed_fetch: Boolean,
     val default_post_listing_mode: PostListingMode /* "list" | "card" | "small_card" */,
     val default_post_sort_type: SortType /* "active" | "hot" | "new" | "old" | "top" | "most_comments" | "new_comments" | "controversial" | "scaled" */,
-    val default_comment_sort_type: SortType /* "hot" | "top" | "new" | "old" | "controversial" */,
+    val default_comment_sort_type: CommentSortType,
     val oauth_registration: Boolean,
     val post_upvotes: FederationMode /* "all" | "local" | "disable" */,
     val post_downvotes: FederationMode /* "all" | "local" | "disable" */,

--- a/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/v1/x0/x0/datatypes/LocalUser.kt
+++ b/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/v1/x0/x0/datatypes/LocalUser.kt
@@ -3,6 +3,7 @@ package it.vercruysse.lemmyapi.v1.x0.x0.datatypes
 import it.vercruysse.lemmyapi.enums.ListingType
 import it.vercruysse.lemmyapi.enums.PostListingMode
 import it.vercruysse.lemmyapi.enums.SortType
+import it.vercruysse.lemmyapi.enums.CommentSortType
 import it.vercruysse.lemmyapi.enums.VoteShow
 import kotlinx.serialization.Serializable
 
@@ -32,7 +33,7 @@ internal data class LocalUser(
     val collapse_bot_comments: Boolean,
     val last_donation_notification_at: String,
     val private_messages_enabled: Boolean,
-    val default_comment_sort_type: SortType /* "hot" | "top" | "new" | "old" | "controversial" */,
+    val default_comment_sort_type: CommentSortType,
     val auto_mark_fetched_posts_as_read: Boolean,
     val hide_media: Boolean,
     val default_post_time_range_seconds: Long? = null,

--- a/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/v1/x0/x0/datatypes/SaveUserSettings.kt
+++ b/app/src/commonMain/kotlin/it/vercruysse/lemmyapi/v1/x0/x0/datatypes/SaveUserSettings.kt
@@ -16,7 +16,7 @@ internal data class SaveUserSettings(
     val default_post_sort_type: SortType? /* "active" | "hot" | "new" | "old" | "top" | "most_comments" | "new_comments" | "controversial" | "scaled" */ = null,
     val default_post_time_range_seconds: Long? = null,
     val default_items_per_page: Long? = null,
-    val default_comment_sort_type: SortType? /* "hot" | "top" | "new" | "old" | "controversial" */ = null,
+    val default_comment_sort_type: CommentSortType? = null,
     val interface_language: String? = null,
     val display_name: String? = null,
     val email: SensitiveString? = null,


### PR DESCRIPTION
Not sure if I did this correctly, and also for some reason even a local `./gradlew build` doesn't work correctly:

```
Could not determine the dependencies of task ':app:kspAndroidMain'.
> SDK location not found. Define a valid SDK location with an ANDROID_HOME environment variable or by setting the sdk.dir path in your project's local properties file at '/LemmyBackwardsCompatibleAPI/local.properties'.
```

